### PR TITLE
Copy block before adding it to collection

### DIFF
--- a/JockeyJS/includes/Jockey.m
+++ b/JockeyJS/includes/Jockey.m
@@ -55,7 +55,7 @@
         complete();
     };
     
-    [self on:type performAsync:extended];
+    [self on:type performAsync:[extended copy]];
 }
 
 + (void)on:(NSString *)type performAsync:(JockeyAsyncHandler)handler


### PR DESCRIPTION
I can provide (if necessary) an example project where if you don't copy the block before adding it to the collection crashes the app because the block gets autoreleased.

For more info see [here](http://www.friday.com/bbum/2009/08/29/blocks-tips-tricks/) and [here](http://stackoverflow.com/a/7999115/536113).
