### PR TITLE
Changes iOSDispatcher to use iframes to dispatch events

### DIFF
--- a/JockeyJS/js/jockey.js
+++ b/JockeyJS/js/jockey.js
@@ -66,7 +66,12 @@
 				delete dispatcher.callbacks[envelope.id];
 			};
 
-			window.location.href = "jockey://" + type + "/" + envelope.id + "?" + encodeURIComponent(JSON.stringify(envelope));
+			var src = "jockey://" + type + "/" + envelope.id + "?" + encodeURIComponent(JSON.stringify(envelope));
+      var iframe = document.createElement("iframe"); 
+      iframe.setAttribute("src", src); 
+      document.documentElement.appendChild(iframe); 
+      iframe.parentNode.removeChild(iframe); 
+      iframe = null; 
 		}
 	};
 


### PR DESCRIPTION
Instead of using window.location.href to trigger
the webView:shouldStartLoadWithRequest:navigationType:
in the UIWebView's delegate now it creates a new
iframe and set its source to the same URL
usend in window.location.href.

This is done because I was doing several calls to the native code and only the last one was reaching. Using iframes make it work
