### PR TITLE
Fix JockeyJS for Android - AndroidDispatcher not needed

### DIFF
--- a/JockeyJS/js/jockey.js
+++ b/JockeyJS/js/jockey.js
@@ -187,7 +187,7 @@
     var UIWebView = /(iPhone|iPod|iPad).*AppleWebKit(?!.*Safari)/i.test(navigator.userAgent);
 	var isAndroid = navigator.userAgent.toLowerCase().indexOf("android") > -1;
 	
-    if ((iOS && UIWebView) || isAndroid) {
+    if ((iOS && UIWebView) || isAndroid) { 
         Jockey.dispatcher = Dispatcher;
     } else {
         Jockey.dispatcher = nullDispatcher;


### PR DESCRIPTION
AndroidDispatcher never completed - isn't actually needed.
iOSDispatcher works for both android and ios. 
AndroidDispatcher was written to be seperate as on android it can't handle listening to jockey://... protocol.
This is handled however in one of the java jockey files for android, checks the url to see if it contains the protocol and replaces with http:// I believe.

This refactor simple renames iOSDispatcher to Dispatcher, remove AndroidDispatcher, and at the bottom of the file checks to see if it's an iOS device OR android, then sets the Jockey.dispatcher to Dispatcher.
If it's a desktop browser, still uses nullDispatcher (for testing purposes)
