### PR TITLE
Allow completed callback to be raised for nullDispatcher

### DIFF
--- a/JockeyJS/js/jockey.js
+++ b/JockeyJS/js/jockey.js
@@ -162,7 +162,7 @@
 
     // i.e., on a Desktop browser.
     var nullDispatcher = {
-        send: function() {},
+        send: function(envelope, complete) { complete(); },
         triggerCallback: function() {},
         sendCallback: function() {}
     };


### PR DESCRIPTION
When testing/developing on a desktop browser the `completed()` callback of the `#send` method is never raised.
This PL adds the call to the `completed()` callback in the `nullDispatcher`
