### PR TITLE
Adding WKWebView support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ DerivedData
 .idea/
 
 /JockeyJSAndroidSample/bin
+.*.sw*

--- a/JockeyJS/includes/Jockey.m
+++ b/JockeyJS/includes/Jockey.m
@@ -51,7 +51,8 @@
 
 + (void)on:(NSString*)type perform:(JockeyHandler)handler
 {
-    void (^ extended)(NSDictionary *payload, void (^ complete)()) = ^(NSDictionary *payload, void(^ complete)()) {
+	void (^ extended)(UIWebView *webView, NSDictionary *payload, void (^ complete)()) = ^(UIWebView *webView, NSDictionary *payload, void(^ complete)()) {
+    //void (^ extended)(NSDictionary *payload, void (^ complete)()) = ^(NSDictionary *payload, void(^ complete)()) {
         handler(payload);
         complete();
     };

--- a/JockeyJS/includes/Jockey.m
+++ b/JockeyJS/includes/Jockey.m
@@ -161,7 +161,7 @@
     };
     
     for (JockeyAsyncHandler handler in listenerList) {
-        handler(payload, complete);
+        handler(webView, payload, complete);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This repo is forked to add a temporary solution for WKWebView support.
+===
+Eventually `JockeyJS` will be removed from WKWebView, but to support some testing code, this project is created.
+
 JockeyJS
 ========
 
@@ -350,5 +354,4 @@ Contributors
 
 * @tcoulter - original author (iOS only)
 * @paulpdaniels - Android support
-
 


### PR DESCRIPTION
When I'm adding support for `WKWebView` so that my app supports `iOS 7` and `iOS 8` at the same time, I found it's possible to add most of my changes on the app side, mostly including handling `jockey://event/xxx` messages with my own code. Surely it would be good to add this to `Jockey` but it will involve some interface changes. Anyhow, the only change I need to made to `Jockey` is the `+ (void)send:(NSString *)type withPayload:(id)payload toWebView:(UIWebView *)webView` call. When I need to send from app to web, the receiver has to be a `UIWebView`. So I added minimal modification by making it's possible to pass a `WKWebView` as a `UIWebView` (of course in this case either a protocol should be created or the type should be simply changed to `id`, but I don't want to change too much to exisiting `Jockey`).

Cheers.
