### PR TITLE
Fix iOS error by checking whether a call back exists before trying to…

### DIFF
--- a/JockeyJS/js/jockey.js
+++ b/JockeyJS/js/jockey.js
@@ -46,8 +46,13 @@
 
             // Alerts within JS callbacks will sometimes freeze the iOS app.
             // Let's wrap the callback in a timeout to prevent this.
-            setTimeout(function() {
+            setTimeout(function () {
                 dispatcher.callbacks[id]();
+                if (id in dispatcher.callbacks) {
+                    dispatcher.callbacks[id]();
+                } else {
+                    throw new Error('Callback with id ' + id + ' does not exist')
+                }
             }, 0);
         },
 


### PR DESCRIPTION
For iOS devices, jockeyjs clientside is not checking if a callback exists when it tries to call them - causing the error. 
When a callback does exist, once it has been called it will delete it from the object of callbacks, which will mean duplicate callback triggers with the same ID will fail.